### PR TITLE
Set up 2 different listeners using goroutine

### DIFF
--- a/server.go
+++ b/server.go
@@ -11,7 +11,21 @@ type User struct {
 	Password string `json:"pass"`
 }
 
+type WorkerConf struct {
+	Port string
+}
+
 func main() {
+	// Run an instance though a goroutine
+	conf1 := WorkerConf{":3001"}
+	go mainApiWorker(conf1)
+
+	// Run an instance in the main thread
+	conf2 := WorkerConf{":3002"}
+	altApiWorker(conf2)
+}
+
+func mainApiWorker(conf WorkerConf) {
 	router := gin.Default()
 
 	v1 := router.Group("/v1")
@@ -20,11 +34,18 @@ func main() {
 		v1.GET("/hello", getHello)
 		v1.PUT("/user/:id", putUser)
 	}
-	v2 := router.Group("/v2")
+	router.Run(conf.Port) // listen and server on 0.0.0.0:3001
+}
+
+func altApiWorker(conf WorkerConf) {
+	router := gin.Default()
+
+	admin := router.Group("/admin")
 	{
-		v2.POST("/user", postUser)
+		admin.GET("/hello", getHelloAdmin)
+		admin.POST("/user", postUser)
 	}
-	router.Run() // listen and server on 0.0.0.0:8080
+	router.Run(conf.Port) // listen and server on 0.0.0.0:3002
 }
 
 func putUser(c *gin.Context) {
@@ -59,6 +80,15 @@ func getHello(c *gin.Context) {
 	} else {
 		str = fmt.Sprint("Hello, World!")
 	}
+	c.JSON(http.StatusOK, gin.H{
+		"message": str,
+	})
+}
+
+func getHelloAdmin(c *gin.Context) {
+	var str string
+	str = fmt.Sprint("Hello, Admin!")
+
 	c.JSON(http.StatusOK, gin.H{
 		"message": str,
 	})


### PR DESCRIPTION
We want to be able to listen on 2 different ports and serve
a different set of endpoints for each listener.

The implementation uses a basic goroutine which is needed since
the `router.Run()` call is blocking.
